### PR TITLE
Reduce min SDK to 16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "protect.babymonitor"
-        minSdkVersion 17
+        minSdkVersion 16
         targetSdkVersion 17
     }
 

--- a/app/src/main/res/layout/available_children_list.xml
+++ b/app/src/main/res/layout/available_children_list.xml
@@ -6,5 +6,7 @@
     android:textAppearance="?android:attr/textAppearanceListItemSmall"
     android:gravity="center_vertical"
     android:paddingStart="16dp"
+    android:paddingLeft="16dp"
     android:paddingEnd="16dp"
+    android:paddingRight="16dp"
     android:minHeight="?android:attr/listPreferredItemHeightSmall" />

--- a/app/src/main/res/layout/available_children_list.xml
+++ b/app/src/main/res/layout/available_children_list.xml
@@ -5,6 +5,6 @@
     android:layout_height="wrap_content"
     android:textAppearance="?android:attr/textAppearanceListItemSmall"
     android:gravity="center_vertical"
-    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
-    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
     android:minHeight="?android:attr/listPreferredItemHeightSmall" />


### PR DESCRIPTION
It turns out that the min SDK the application will support is 16, as the NsdManager is available only at SDK 16 and above.

https://github.com/brarcher/protect-baby-monitor/issues/20#issuecomment-329234508